### PR TITLE
Fix Lovakengj typo in XericsDefinitions.json

### DIFF
--- a/src/main/resources/XericsMap/XericsDefinitions.json
+++ b/src/main/resources/XericsMap/XericsDefinitions.json
@@ -41,7 +41,7 @@
       "y": 129
     },
     "label": {
-      "title": "Lovakenjg",
+      "title": "Lovakengj",
       "x": 200,
       "y": 98,
       "width": 100


### PR DESCRIPTION
Changes "Lovakenjg" to correct spelling of "Lovakengj" on the Xeric's talisman map. Closes #26 and #40 
